### PR TITLE
Check default files for public keys if not set up in ~/.ssh/config.

### DIFF
--- a/src/main/java/net/imagej/plugins/uploaders/ssh/SSHSessionCreator.java
+++ b/src/main/java/net/imagej/plugins/uploaders/ssh/SSHSessionCreator.java
@@ -114,6 +114,9 @@ final class SSHSessionCreator {
 			result.sshHost = sshHost.substring(0, colon);
 		}
 		result.readUserSSHConfig(log);
+		if (result.identity == null) {
+			result.getUserDefaultKeys();
+		}
 		return result;
 	}
 
@@ -166,6 +169,22 @@ final class SSHSessionCreator {
 				log.error(e);
 			}
 		}
+
+		// Checks for presence of the default IdentityFiles, in the
+		// users home directory, i.e., ~/.ssh/id_rsa and ~/.ssh/id_dsa
+		private void getUserDefaultKeys()
+		{
+			final String[] filenames = { "id_rsa", "id_dsa" };
+			final File userSSHDir = new File(System.getProperty("user.home"), ".ssh");
+			for (String f : filenames) {
+				final File keyfile = new File(userSSHDir, f);
+				if (keyfile.exists()) {
+					identity = keyfile.getAbsolutePath();
+					break;
+				}
+			}
+		}
+
 	}
 
 	protected static UserInfo getUserInfo(final String initialPrompt, final String password) {


### PR DESCRIPTION
Basically, if `~/.ssh/config` does not have an `IdentityFile` field, it will check `~/.ssh/id_rsa` and `~/.ssh/id_dsa`. At the moment, it was simply failing with "Could not initialize update site".

I took the parsing of the config file out into a separate method because it seems, according to ssh_config(5), that there's a lot more ways to specify where the identity files could be and it seemed that this would keep it cleaner in the future.

For future note, it appears that it might make more sense to collect an array of available identity files, which would be tried later on:

> It is possible to have multiple identity files specified in configuration files; all
> these identities will be tried in sequence.  Multiple IdentityFile directives will add to
> the list of identities tried (this behaviour differs from that of other configuration
> directives).
